### PR TITLE
Enable strict language features (#653)

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,8 +1,10 @@
 include: package:lints/recommended.yaml
 
 analyzer:
-  strong-mode:
-    implicit-casts: false
+  language:
+    strict-casts: true
+    strict-raw-types: true
+    strict-inference: true
 
 linter:
   rules:

--- a/lib/retry.dart
+++ b/lib/retry.dart
@@ -119,7 +119,7 @@ class RetryClient extends BaseClient {
         _unawaited(response.stream.listen((_) {}).cancel().catchError((_) {}));
       }
 
-      await Future.delayed(_delay(i));
+      await Future<void>.delayed(_delay(i));
       _onRetry?.call(request, response, i);
       i++;
     }

--- a/lib/src/base_client.dart
+++ b/lib/src/base_client.dart
@@ -73,7 +73,7 @@ abstract class BaseClient implements Client {
   /// Sends a non-streaming [Request] and returns a non-streaming [Response].
   Future<Response> _sendUnstreamed(
       String method, Uri url, Map<String, String>? headers,
-      [body, Encoding? encoding]) async {
+      [Object? body, Encoding? encoding]) async {
     var request = Request(method, url);
 
     if (headers != null) request.headers.addAll(headers);

--- a/lib/src/io_client.dart
+++ b/lib/src/io_client.dart
@@ -49,7 +49,7 @@ class IOClient extends BaseClient {
       });
 
       return IOStreamedResponse(
-          response.handleError((error) {
+          response.handleError((Object error) {
             final httpException = error as HttpException;
             throw ClientException(httpException.message, httpException.uri);
           }, test: (error) => error is HttpException),

--- a/test/multipart_test.dart
+++ b/test/multipart_test.dart
@@ -244,6 +244,6 @@ void main() {
     var file = http.MultipartFile(
         'file', Future<List<int>>.error('error').asStream(), 1);
     var request = http.MultipartRequest('POST', dummyUrl)..files.add(file);
-    expect(request.finalize().drain(), throwsA('error'));
+    expect(request.finalize().drain<void>(), throwsA('error'));
   });
 }

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -48,7 +48,7 @@ class _Parse extends Matcher {
   _Parse(this._matcher);
 
   @override
-  bool matches(Object? item, Map matchState) {
+  bool matches(Object? item, Map<dynamic, dynamic> matchState) {
     if (item is String) {
       dynamic parsed;
       try {
@@ -80,7 +80,7 @@ class _BodyMatches extends Matcher {
   _BodyMatches(this._pattern);
 
   @override
-  bool matches(Object? item, Map matchState) {
+  bool matches(Object? item, Map<dynamic, dynamic> matchState) {
     if (item is http.MultipartRequest) {
       return completes.matches(_checks(item), matchState);
     }


### PR DESCRIPTION
Migrate from `implicit-casts: false` to `strict-casts: true` and enable
`string-raw-types` and `strict-inference`.